### PR TITLE
Add a new `min-bptree` feature which is known to avoid UB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ arcache-is-hashmap = ["arcache"]
 arcache-is-hashtrie = ["arcache"]
 simd_support = []
 
+min-bptree = ["crossbeam-utils", "smallvec"]
+
 [dependencies]
 ahash = { version = "0.8", optional = true }
 crossbeam-utils = { version = "0.8.12", optional = true }

--- a/src/bptree/impl.rs
+++ b/src/bptree/impl.rs
@@ -1,6 +1,7 @@
 use crate::internals::bptree::cursor::CursorReadOps;
 use crate::internals::bptree::cursor::{CursorRead, CursorWrite, SuperBlock};
 use crate::internals::bptree::iter::{Iter, KeyIter, RangeIter, ValueIter};
+#[cfg(feature = "maps")]
 use crate::internals::bptree::mutiter::RangeMutIter;
 use crate::internals::lincowcell::LinCowCellCapable;
 use std::borrow::Borrow;
@@ -279,6 +280,7 @@ impl<K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 's
     }
 
     /// Iterate over a mutable range of values
+    #[cfg(feature = "maps")]
     pub fn range_mut<R, T>(&mut self, range: R) -> RangeMutIter<K, V>
     where
         K: Borrow<T>,

--- a/src/internals/bptree/cursor.rs
+++ b/src/internals/bptree/cursor.rs
@@ -66,8 +66,8 @@ impl<K: Clone + Ord + Debug, V: Clone> LinCowCellCapable<CursorRead<K, V>, Curso
         // Now when the lock is dropped, both sides see the correct info and garbage for drops.
 
         // We are done, time to seal everything.
-        new.first_seen.iter().for_each(|n| unsafe {
-            (**n).make_ro();
+        new.first_seen.iter().for_each(|n| {
+            Node::make_ro_raw(*n);
         });
         // Clear first seen, we won't be dropping them from here.
         new.first_seen.clear();

--- a/src/internals/bptree/cursor.rs
+++ b/src/internals/bptree/cursor.rs
@@ -184,8 +184,8 @@ pub(crate) trait CursorReadOps<K: Clone + Ord + Debug, V: Clone> {
     #[cfg(test)]
     fn get_tree_density(&self) -> (usize, usize) {
         // Walk the tree and calculate the packing efficiency.
-        let rref = self.get_root_ref();
-        rref.tree_density()
+        let rref = self.get_root();
+        Node::tree_density_raw(rref)
     }
 
     fn search<Q>(&self, k: &Q) -> Option<&V>
@@ -273,7 +273,7 @@ pub(crate) trait CursorReadOps<K: Clone + Ord + Debug, V: Clone> {
 
     #[cfg(test)]
     fn verify(&self) -> bool {
-        self.get_root_ref().no_cycles() && self.get_root_ref().verify() && {
+        Node::no_cycles_raw(self.get_root()) && Node::verify_raw(self.get_root()) && {
             let (l, _) = self.get_tree_density();
             l == self.len()
         }
@@ -604,7 +604,7 @@ impl<K: Clone + Ord + Debug, V: Clone> Drop for SuperBlock<K, V> {
         let mut first_seen = Vec::with_capacity(16);
         // eprintln!("{:?}", self.root);
         first_seen.push(self.root);
-        unsafe { (*self.root).sblock_collect(&mut first_seen) };
+        Node::sblock_collect_raw(self.root, &mut first_seen);
         first_seen.iter().for_each(|n| Node::free(*n));
     }
 }

--- a/src/internals/bptree/cursor.rs
+++ b/src/internals/bptree/cursor.rs
@@ -554,7 +554,7 @@ impl<K: Clone + Ord + Debug, V: Clone> CursorWrite<K, V> {
 
     #[cfg(test)]
     pub(crate) fn tree_density(&self) -> (usize, usize) {
-        self.get_root_ref().tree_density()
+        Node::<K, V>::tree_density_raw(self.get_root())
     }
 
     pub(crate) fn range_mut<'n, R, T>(&'n mut self, range: R) -> RangeMutIter<'n, 'n, K, V>

--- a/src/internals/bptree/cursor.rs
+++ b/src/internals/bptree/cursor.rs
@@ -250,7 +250,7 @@ pub(crate) trait CursorReadOps<K: Clone + Ord + Debug, V: Clone> {
         panic!("Tree depth exceeded max limit (65536). This may indicate memory corruption.");
     }
 
-    fn range<'n, R, T>(&'n self, range: R) -> RangeIter<'n, '_, K, V>
+    fn range<'n, R, T>(&'n self, range: R) -> RangeIter<'n, 'n, K, V>
     where
         K: Borrow<T>,
         T: Ord + ?Sized,
@@ -259,15 +259,15 @@ pub(crate) trait CursorReadOps<K: Clone + Ord + Debug, V: Clone> {
         RangeIter::new(self.get_root(), range, self.len())
     }
 
-    fn kv_iter<'n>(&'n self) -> Iter<'n, '_, K, V> {
+    fn kv_iter<'n>(&'n self) -> Iter<'n, 'n, K, V> {
         Iter::new(self.get_root(), self.len())
     }
 
-    fn k_iter<'n>(&'n self) -> KeyIter<'n, '_, K, V> {
+    fn k_iter<'n>(&'n self) -> KeyIter<'n, 'n, K, V> {
         KeyIter::new(self.get_root(), self.len())
     }
 
-    fn v_iter<'n>(&'n self) -> ValueIter<'n, '_, K, V> {
+    fn v_iter<'n>(&'n self) -> ValueIter<'n, 'n, K, V> {
         ValueIter::new(self.get_root(), self.len())
     }
 
@@ -557,7 +557,7 @@ impl<K: Clone + Ord + Debug, V: Clone> CursorWrite<K, V> {
         self.get_root_ref().tree_density()
     }
 
-    pub(crate) fn range_mut<'n, R, T>(&'n mut self, range: R) -> RangeMutIter<'n, '_, K, V>
+    pub(crate) fn range_mut<'n, R, T>(&'n mut self, range: R) -> RangeMutIter<'n, 'n, K, V>
     where
         K: Borrow<T>,
         T: Ord + ?Sized,

--- a/src/internals/bptree/cursor.rs
+++ b/src/internals/bptree/cursor.rs
@@ -105,19 +105,19 @@ impl<K: Clone + Ord + Debug, V: Clone> SuperBlock<K, V> {
         // let last_seen: Vec<*mut Node<K, V>> = Vec::with_capacity(16);
         let mut first_seen = Vec::with_capacity(16);
         // Do a pre-verify to be sure it's sane.
-        assert!(unsafe { (*root).verify() });
+        assert!(Node::verify_raw(root));
         // Collect anythinng from root into this txid if needed.
         // Set txid to txid on all tree nodes from the root.
         first_seen.push(root);
-        unsafe { (*root).sblock_collect(&mut first_seen) };
+        Node::sblock_collect_raw(root, &mut first_seen);
 
         // Lock them all
-        first_seen.iter().for_each(|n| unsafe {
-            (**n).make_ro();
+        first_seen.iter().for_each(|n| {
+            Node::make_ro_raw(*n);
         });
 
         // Determine our count internally.
-        let (length, _) = unsafe { (*root).tree_density() };
+        let (length, _) = Node::tree_density_raw(root);
 
         // Good to go!
         SuperBlock {
@@ -1096,7 +1096,7 @@ where
     K: Clone + Ord + Debug + 'a,
     V: Clone,
 {
-    if self_meta!(node).is_leaf() {
+    if unsafe {&* node}.meta.is_leaf() {
         leaf_ref!(node, K, V).get_mut_ref(k)
     } else {
         // This nmref binds the life of the reference ...

--- a/src/internals/bptree/cursor.rs
+++ b/src/internals/bptree/cursor.rs
@@ -11,6 +11,7 @@ use std::fmt::Debug;
 use std::mem;
 
 use super::iter::{Iter, KeyIter, RangeIter, ValueIter};
+#[cfg(feature = "maps")]
 use super::mutiter::RangeMutIter;
 use super::states::*;
 use std::ops::RangeBounds;
@@ -557,6 +558,7 @@ impl<K: Clone + Ord + Debug, V: Clone> CursorWrite<K, V> {
         Node::<K, V>::tree_density_raw(self.get_root())
     }
 
+    #[cfg(feature = "maps")]
     pub(crate) fn range_mut<'n, R, T>(&'n mut self, range: R) -> RangeMutIter<'n, 'n, K, V>
     where
         K: Borrow<T>,
@@ -1096,7 +1098,7 @@ where
     K: Clone + Ord + Debug + 'a,
     V: Clone,
 {
-    if unsafe {&* node}.meta.is_leaf() {
+    if unsafe { &*node }.meta.is_leaf() {
         leaf_ref!(node, K, V).get_mut_ref(k)
     } else {
         // This nmref binds the life of the reference ...

--- a/src/internals/bptree/iter.rs
+++ b/src/internals/bptree/iter.rs
@@ -140,7 +140,7 @@ impl<'a, K: Clone + Ord + Debug, V: Clone> Iterator for LeafIter<'a, K, V> {
 
         // Return the leaf as we found at the start, regardless of the
         // stack operations.
-        Some(leaf_ref!(leafref, K, V))
+        Some(leaf_ref_shared!(leafref, K, V))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -181,7 +181,8 @@ where
                 }
                 break;
             } else {
-                let bref = branch_ref!(work_node, K, V);
+                let bref = branch_ref_shared!(work_node, K, V);
+                let bref_count = bref.count();
                 match bound {
                     Bound::Excluded(q) | Bound::Included(q) => {
                         let idx = bref.locate_node(q);
@@ -192,8 +193,8 @@ where
                     }
                     Bound::Unbounded => {
                         // count shows the most right node.
-                        stack.push_back((work_node, bref.count()));
-                        work_node = branch_ref!(work_node, K, V).get_idx_unchecked(bref.count());
+                        stack.push_back((work_node, bref_count));
+                        work_node = branch_ref!(work_node, K, V).get_idx_unchecked(bref_count);
                     }
                 }
             }
@@ -297,7 +298,7 @@ impl<'a, K: Clone + Ord + Debug, V: Clone> Iterator for RevLeafIter<'a, K, V> {
 
         // Return the leaf as we found at the start, regardless of the
         // stack operations.
-        Some(leaf_ref!(leafref, K, V))
+        Some(leaf_ref_shared!(leafref, K, V))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -671,7 +672,7 @@ impl<K: Clone + Ord + Debug, V: Clone> DoubleEndedIterator for RangeIter<'_, '_,
     fn next_back(&mut self) -> Option<Self::Item> {
         loop {
             if let Some((node, idx)) = self.right_iter.get_mut() {
-                let leaf = leaf_ref!(*node, K, V);
+                let leaf = leaf_ref_shared!(*node, K, V);
                 // Get idx checked.
                 if let Some(r) = leaf.get_kv_idx_checked(*idx) {
                     if let Some((lnode, lidx)) = self.left_iter.get_mut() {

--- a/src/internals/bptree/macros.rs
+++ b/src/internals/bptree/macros.rs
@@ -23,6 +23,24 @@ macro_rules! branch_ref {
     }};
 }
 
+/// Like [`branch_ref`], but yields &Leaf without coercing from &mut Leaf. This is useful
+/// to avoid triggering Miri's analysis.
+macro_rules! branch_ref_shared {
+    ($x:expr, $k:ty, $v:ty) => {{
+        debug_assert!(unsafe { (*$x).meta.is_branch() });
+        unsafe { &*($x as *const Branch<$k, $v>) }
+    }};
+}
+
+/// Like [`leaf_ref`], but yields &Leaf without coercing from &mut Leaf. This is useful
+/// to avoid triggering Miri's analysis.
+macro_rules! leaf_ref_shared {
+    ($x:expr, $k:ty, $v:ty) => {{
+        debug_assert!(unsafe { (*$x).meta.is_leaf() });
+        unsafe { &*($x as *const Leaf<$k, $v>) }
+    }};
+}
+
 macro_rules! leaf_ref {
     ($x:expr, $k:ty, $v:ty) => {{
         debug_assert!(unsafe { (*$x).meta.is_leaf() });

--- a/src/internals/bptree/mod.rs
+++ b/src/internals/bptree/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod macros;
 pub(crate) mod cursor;
 pub mod iter;
+#[cfg(feature = "maps")]
 pub mod mutiter;
 pub(crate) mod node;
 pub(crate) mod states;

--- a/src/internals/bptree/node.rs
+++ b/src/internals/bptree/node.rs
@@ -1079,7 +1079,9 @@ impl<K: Ord + Clone + Debug, V: Clone> Branch<K, V> {
     }
 
     pub(crate) fn min_raw<'a>(pointer: *const Self) -> *const K {
-        unsafe { &*pointer }.min()
+        let this = unsafe { &*pointer };
+        debug_assert_branch!(this);
+        Node::min_raw(this.nodes[0])
     }
 
     // Can't inline as this is recursive!
@@ -1091,7 +1093,11 @@ impl<K: Ord + Clone + Debug, V: Clone> Branch<K, V> {
     }
 
     pub(crate) fn max_raw(pointer: *const Self) -> *const K {
-        unsafe { &*pointer }.max()
+        let this = unsafe { &*pointer };
+        debug_assert_branch!(this);
+        // Remember, self.count() is + 1 offset, so this gets
+        // the max node
+        Node::max_raw(this.nodes[this.count()])
     }
 
     pub(crate) fn min_node(&self) -> *mut Node<K, V> {
@@ -1204,7 +1210,7 @@ impl<K: Ord + Clone + Debug, V: Clone> Branch<K, V> {
             // 2 * The inserted node is between max - 1 and max, causing l(node, max) to be returned.
             // 3 * The inserted node is a low/middle value, causing max and max -1 to be returned.
             //
-            let kr = unsafe { (*node).min() };
+            let kr = unsafe { &*Node::min_raw(node) };
             let r = key_search!(self, kr);
             let ins_idx = r.unwrap_err();
             // Everything will pop max.

--- a/src/internals/mod.rs
+++ b/src/internals/mod.rs
@@ -10,7 +10,9 @@
 //! ⚠️   ⚠️   ⚠️
 
 pub mod bptree;
+#[cfg(feature = "maps")]
 pub mod hashmap;
+#[cfg(feature = "maps")]
 pub mod hashtrie;
 pub mod lincowcell;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,11 @@
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
 #[cfg(feature = "maps")]
-#[macro_use]
+#[cfg_attr(feature = "maps", macro_use)]
 extern crate smallvec;
+
+#[cfg(feature = "maps")]
+compile_error!("The 'maps' feature enables code that may contain undefined behavior! Only the min-bptree feature is known to be safe");
 
 pub mod cowcell;
 pub use cowcell::CowCell;
@@ -62,13 +65,13 @@ pub mod arcache;
 pub mod threadcache;
 
 // This is where the scary rust lives.
-#[cfg(feature = "maps")]
+#[cfg(any(feature = "maps", feature = "min-bptree"))]
 pub mod internals;
 // This is where the good rust lives.
-#[cfg(feature = "maps")]
+#[cfg(any(feature = "maps", feature = "min-bptree"))]
 mod utils;
 
-#[cfg(feature = "maps")]
+#[cfg(any(feature = "maps", feature = "min-bptree"))]
 pub mod bptree;
 #[cfg(feature = "maps")]
 pub mod hashmap;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,12 +22,10 @@ pub(crate) unsafe fn slice_insert<T>(slice: &mut [T], new: T, idx: usize) {
 // From std::collections::btree::node.rs
 pub(crate) unsafe fn slice_remove<T>(slice: &mut [T], idx: usize) -> T {
     // setup the value to be returned, IE give ownership to ret.
+    let len = slice.len();
     let ret = ptr::read(slice.get_unchecked(idx));
-    ptr::copy(
-        slice.as_ptr().add(idx + 1),
-        slice.as_mut_ptr().add(idx),
-        slice.len() - idx - 1,
-    );
+    let slice = slice.as_mut_ptr();
+    ptr::copy(slice.add(idx + 1), slice.add(idx), len - idx - 1);
     ret
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,13 +13,10 @@ use std::ptr;
 use serde::de::{Deserialize, MapAccess, Visitor};
 
 pub(crate) unsafe fn slice_insert<T>(slice: &mut [T], new: T, idx: usize) {
-    // miri doesn't like this
-    ptr::copy(
-        slice.as_ptr().add(idx),
-        slice.as_mut_ptr().add(idx + 1),
-        slice.len() - idx - 1,
-    );
-    ptr::write(slice.get_unchecked_mut(idx), new);
+    let len = slice.len();
+    let slice = slice.as_mut_ptr();
+    ptr::copy(slice.add(idx), slice.add(idx + 1), len - idx - 1);
+    ptr::write(slice.add(idx), new);
 }
 
 // From std::collections::btree::node.rs


### PR DESCRIPTION
This PR does two things:
1. Fix numerous (probably inconsequential) violations of Stacked Borrows throughout the `bptree` codebase.
  - In general, the only thing needed to fix these violations is to avoid back-and-forth conversions between `*const T` and `&T` which interfere with Miri's analysis. Since we never actually use either kind of reference to mutate state, these violations were almost certainly harmless - but fixing them gives additional assurance of correctness. 
  -  The one exception to this rule is in the `RangeIterMut` implementation. This iterator does _**seem**_ to have real Undefined Behavior in that it mutably iterates over the tree while holding a shared reference to a key that lives in the tree. A more detailed analysis may show that the limited mutation allowed by the type cannot invalidate the reference, though.
2. Add a new `bptree-min` feature which removes every item that might cause UB. 